### PR TITLE
always discover device and then check address

### DIFF
--- a/bluebattery/device.py
+++ b/bluebattery/device.py
@@ -40,6 +40,9 @@ class BBDeviceManager(gatt.DeviceManager):
         super().stop()
 
     def device_discovered(self, device):
+        if self.target_device.mac_address != device.mac_address:
+            self.log.debug(f"Different Device discovered: {device.mac_address}.")
+            return  
         self.log.debug(f"Discovery found device: {device.mac_address}.")
         device.advertised()
         self.stop_discovery()
@@ -57,10 +60,10 @@ class BBDeviceManager(gatt.DeviceManager):
     def run(self):
         if self.target_device:
             self.log.debug("Trying to connect target device.")
-            self.target_device.connect()
+            #self.target_device.connect()
         else:
             self.log.debug("No target device given, starting discovery.")
-            self.start_discovery([self.ADVERTISED_SERVICE_ID])
+        self.start_discovery([self.ADVERTISED_SERVICE_ID])
         super().run()
 
 

--- a/bluebattery/device.py
+++ b/bluebattery/device.py
@@ -40,7 +40,7 @@ class BBDeviceManager(gatt.DeviceManager):
         super().stop()
 
     def device_discovered(self, device):
-        if self.target_device.mac_address != device.mac_address:
+        if self.target_device and self.target_device.mac_address != device.mac_address:
             self.log.debug(f"Different Device discovered: {device.mac_address}.")
             return  
         self.log.debug(f"Discovery found device: {device.mac_address}.")

--- a/bluebattery/device.py
+++ b/bluebattery/device.py
@@ -42,6 +42,7 @@ class BBDeviceManager(gatt.DeviceManager):
     def device_discovered(self, device):
         if self.target_device and self.target_device.mac_address != device.mac_address:
             self.log.debug(f"Different Device discovered: {device.mac_address}.")
+            super().device_discovered(device)
             return  
         self.log.debug(f"Discovery found device: {device.mac_address}.")
         device.advertised()


### PR DESCRIPTION
There have been issues that a connection to a given Mac address did not go through. Auto discover mode always succeeded. After a successful auto discover session, a 2nd connection was possible with a given mac address.

So this change always uses discover mode and in case of a given mac address it only connects when the discovered device mac address is equal to the given one. Tested on  Raspberry Pi Zero W2 with Bluez 5.55.