### PR TITLE
Add username and password support for MQTT command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ $ bb_mqtt --host my-mqtt.server.example
 
 Use `--collect` to get a more concise MQTT output using JSON objects.
 
+Use `--username` and `--password` if your MQTT server is configured to use authentication via username and password.
+
 ## Troubleshooting
 
 Depending on your environment, you may need to enable BLE first or to set up your linux user to allow using BLE:

--- a/bluebattery/cli.py
+++ b/bluebattery/cli.py
@@ -134,6 +134,16 @@ def mqtt():
         default="1883",
     )
     parser.add_argument(
+        "--username",
+        "-u",
+        help="MQTT broker username.",
+    )
+    parser.add_argument(
+        "--password",
+        "-pw",
+        help="MQTT broker password.",
+    )
+    parser.add_argument(
         "--prefix",
         help="Prefix for topics sent from this script.",
         default="service/bluebattery",
@@ -170,6 +180,8 @@ def mqtt():
     mqtt_client.enable_logger(log)
     mqtt_client.will_set(mktopic("online"), "0", retain=True)
     mqtt_client.on_connect = on_connect
+    if args.username and args.password:
+        mqtt_client.username_pw_set(args.username, password=args.password)
     mqtt_client.connect_async(args.host, int(args.port))
     mqtt_client.loop_start()
 


### PR DESCRIPTION
Thank you for this awesome tool, it's one of the most important components of my smartcamper setup!

My MQTT server setup uses a username and password for authentication.
This is supported by the Paho MQTT library, but the CLI MQTT command didn't allow passing through the corresponding arguments. This pull request changes that.

The code is tested in my BlueBattery and MQTT server setup.