### PR TITLE
adapt for BlueBattery firmware version > V418

### DIFF
--- a/bluebattery/bbcharacteristics.py
+++ b/bluebattery/bbcharacteristics.py
@@ -119,18 +119,18 @@ class BCLive(ReadPeriodicCharacteristic):
                 # byte 1: length
                 (0x00, 0x07): frametypes.BCLiveMeasurementsFrame,
                 (0x00, 0x09): frametypes.BCLiveMeasurementsFrameExtended,
-                (0x00, 0x0A): frametypes.BCLiveMeasurementsFrame_0A, ###KS
+                (0x00, 0x0A): frametypes.BCLiveMeasurementsFrameLargeSolarCurrent,
                 (0x01, 0x09): frametypes.BCSolarChargerEBLFrame,
                 (0x01, 0x0B): frametypes.BCSolarChargerStandardFrame,
                 (0x01, 0x0C): frametypes.BCSolarChargerExtendedFrame,
-                (0x01, 0x0F): frametypes.BCSolarChargerLargeSolarCurrent, ###KS
+                (0x01, 0x0F): frametypes.BCSolarChargerLargeSolarCurrent,
                 (0x02, 0x10): frametypes.BCBatteryComputer1Frame,
                 (0x02, 0x11): frametypes.BCBatteryComputer1Frame,
                 (0x03, 0x0F): frametypes.BCBatteryComputer2Frame,
                 (0x04, 0x01): frametypes.BCIntradayLogEntryFrame,
                 (0x05, 0x0A): frametypes.BCBoosterDataFrame,
-                (0x05, 0x0C): frametypes.BCBoosterDataFrameExtended, ###KS
-                (0x05, 0x10): frametypes.BCBoosterDataFrameExtendedBBX, ###KS
+                (0x05, 0x0C): frametypes.BCBoosterDataFrameExtended,
+                (0x05, 0x10): frametypes.BCBoosterDataFrameExtendedBBX,
                 (0x05, 0x04): frametypes.BCNoBoosterDataFrame,
             },
         ).process(self, data)

--- a/bluebattery/bbcharacteristics.py
+++ b/bluebattery/bbcharacteristics.py
@@ -128,6 +128,7 @@ class BCLive(ReadPeriodicCharacteristic):
                 (0x02, 0x11): frametypes.BCBatteryComputer1Frame,
                 (0x03, 0x0F): frametypes.BCBatteryComputer2Frame,
                 (0x04, 0x01): frametypes.BCIntradayLogEntryFrame,
+                (0x04, 0x02): frametypes.BCIntradayLogEntryFrameExtended,
                 (0x05, 0x0A): frametypes.BCBoosterDataFrame,
                 (0x05, 0x0C): frametypes.BCBoosterDataFrameExtended,
                 (0x05, 0x10): frametypes.BCBoosterDataFrameExtendedBBX,

--- a/bluebattery/bbcharacteristics.py
+++ b/bluebattery/bbcharacteristics.py
@@ -88,6 +88,7 @@ class BCLog(ReadPeriodicCharacteristic):
             (0x00,): frametypes.LogEntryDaysFrame,
             (0x01,): frametypes.LogEntryFrameOld,
             (0x02,): frametypes.LogEntryFrameNew,
+            (0x03,): frametypes.LogEntryFrameLargeSolarCurrent, ###KS
         },
         ).process(self, data)
 
@@ -118,13 +119,18 @@ class BCLive(ReadPeriodicCharacteristic):
                 # byte 1: length
                 (0x00, 0x07): frametypes.BCLiveMeasurementsFrame,
                 (0x00, 0x09): frametypes.BCLiveMeasurementsFrameExtended,
+                (0x00, 0x0A): frametypes.BCLiveMeasurementsFrame_0A, ###KS
                 (0x01, 0x09): frametypes.BCSolarChargerEBLFrame,
                 (0x01, 0x0B): frametypes.BCSolarChargerStandardFrame,
                 (0x01, 0x0C): frametypes.BCSolarChargerExtendedFrame,
+                (0x01, 0x0F): frametypes.BCSolarChargerLargeSolarCurrent, ###KS
                 (0x02, 0x10): frametypes.BCBatteryComputer1Frame,
+                (0x02, 0x11): frametypes.BCBatteryComputer1Frame,
                 (0x03, 0x0F): frametypes.BCBatteryComputer2Frame,
                 (0x04, 0x01): frametypes.BCIntradayLogEntryFrame,
                 (0x05, 0x0A): frametypes.BCBoosterDataFrame,
+                (0x05, 0x0C): frametypes.BCBoosterDataFrameExtended, ###KS
+                (0x05, 0x10): frametypes.BCBoosterDataFrameExtendedBBX, ###KS
                 (0x05, 0x04): frametypes.BCNoBoosterDataFrame,
             },
         ).process(self, data)

--- a/bluebattery/commands.py
+++ b/bluebattery/commands.py
@@ -67,17 +67,22 @@ class BBFrame:
     output_id: str  # note: may contain placeholders for output field values
     fields: List[BBValue]
     postprocess: Optional[Callable] = None
+    preprocess: Optional[Callable] = None
 
     def format(self):
         return BYTE_ORDER + "".join(field.get_struct() for field in self.fields)
 
     def process(self, characteristic, value):
+
         non_ignore_fields = filter(
             lambda field: type(field) is not BBValueIgnore, self.fields
         )
 
         # field values, raw from the struct unpacking
         raw_values = zip(non_ignore_fields, struct.unpack_from(self.format(), value))
+
+        if self.preprocess:
+            raw_values = self.preprocess(raw_values)
 
         """
         Frames with multiple sub-frames may contain the same field name twice. Once

--- a/bluebattery/conversions.py
+++ b/bluebattery/conversions.py
@@ -17,10 +17,11 @@ def cnv_10mAh_to_Ah(_10mAh):
 def cnv_mA_to_A(mA):
     return mA / 1000
 
+def cnv_8mA_to_A(_8mA):
+	return _8mA / 125
 
 def cnv_100mA_to_A(_100mA):
     return _100mA / 10
-
 
 cnv_100mV_to_V = cnv_100mA_to_A
 
@@ -35,3 +36,11 @@ def cnv_bb_temp_to_deg_c(bb_temp):
 
 def cnv_solar_status(status):
     return {0: "active", 1: "standby", 2: "reduced"}.get(status, "unknown")
+
+def cnv_charger_phase(phase):
+	return {
+		0: "bulk",
+		1: "absorption",
+		2: "float",
+		3: "care"
+	}.get(phase & 0x0f, "unknown")

--- a/bluebattery/frametypes.py
+++ b/bluebattery/frametypes.py
@@ -157,6 +157,53 @@ LogEntryFrameNew = BBFrame(
     postprocess=add_reverse_day_counter,
 )
 
+LogEntryFrameLargeSolarCurrent = BBFrame(
+    output_id="log/day/-{days_ago}/extended",
+    fields=[
+        # bytes 0-1: 16-bit day counter (relative to current day in frame type 0x00)
+        BBValue("H", "day_counter"),
+        # bytes 2-3: 16-bit wall time in seconds/2
+        BBValue("H", "wall_time", lambda value: value * 2),
+        # bytes 4-5: 16-bit average battery voltage mV
+        BBValue("H", "avg_battery_voltage_V", cnv.cnv_mV_to_V),
+        # bytes 6-7: 16-bit average solar current mA
+        BBValue("H", "avg_solar_current_A", cnv.cnv_8mA_to_A),
+        # bytes 8: solar charger status: aktiv, standby, reduced
+        BBValue("B", "solar_charger_status", cnv.cnv_solar_status),
+        # bytes 9-10: 16-bit average battery current 100 mA
+        BBValue("H", "avg_battery_current_A", cnv.cnv_100mA_to_A),
+        # bytes 11-12: 16-bit battery SOC 100 mAh
+        BBValue("H", "battery_state_of_charge_A", cnv.cnv_mA_to_A),
+        # bytes 13-14: 16-bit booster average input voltage 10mV (starter)**
+        BBValue("H", "avg_booster_input_voltage_V", cnv.cnv_10mV_to_V),
+        # bytes 15-16: signed 16-bit booster average current 100 mA**
+        BBValue("h", "avg_booster_current_A", cnv.cnv_100mA_to_A),
+        # bytes 17+ 0-1: 16-bit day counter (relative to current day in frame type 0x00)
+        BBValue("H", "day_counter"),
+        # bytes 17+ 2-3: 16-bit wall time in seconds/2
+        BBValue("H", "wall_time", lambda value: value * 2),
+        # bytes 17+ 4-5: 16-bit average battery voltage mV
+        BBValue("H", "avg_battery_voltage_V", cnv.cnv_mV_to_V),
+        # bytes 17+ 6-7: 16-bit average solar current mA
+        BBValue("H", "avg_solar_current_A", cnv.cnv_mA_to_A),
+        # bytes 17+ 8: solar charger status: aktiv, standby, reduced
+        BBValue("B", "solar_charger_status", cnv.cnv_solar_status),
+        # bytes 17+ 9-10: 16-bit average battery current 100 mA
+        BBValue("H", "avg_battery_current_A", cnv.cnv_100mA_to_A),
+        # bytes 17+ 11-12: 16-bit battery SOC 100 mAh
+        BBValue("H", "battery_state_of_charge_A", cnv.cnv_mA_to_A),
+        # bytes 17+ 13-14: 16-bit booster average input voltage 10mV (starter)**
+        BBValue("H", "avg_booster_input_voltage_V", cnv.cnv_10mV_to_V),
+        # bytes 17+ 15-16: signed 16-bit booster average current 100 mA**
+        BBValue("h", "avg_booster_current_A", cnv.cnv_100mA_to_A),
+        # bytes 34-35: reserved
+        BBValueIgnore(2),
+        # byte 36: 8-bit frame type 0x01
+        BBValueIgnore(),
+    ],
+    postprocess=add_reverse_day_counter,
+)
+
 
 BCLiveMeasurementsFrame = BBFrame(
     output_id="live/measurement",
@@ -179,6 +226,17 @@ BCLiveMeasurementsFrameExtended = BBFrame(
     + [
         # 2 bytes optional heap size in bytes
         BBValue("H", "heap_size_bytes"), 
+    ],
+)
+
+BCLiveMeasurementsFrame_0A = BBFrame(
+    output_id="live/measurement_ext",
+    fields=BCLiveMeasurementsFrameExtended.fields
+    + [
+        # 1 byte MSB solar charge current
+        # ... 65.536 A per bit..
+        # FIXME: how to add this to "solar_charge_current_A" in place???
+        BBValue("B", "solar_charge_current_up_A", lambda x : x * 0x10000 / 1000),
     ],
 )
 
@@ -237,6 +295,23 @@ BCSolarChargerExtendedFrame = BBFrame(
         #  bit 7: reserved
         BBValue("B", "relay_status", RelayStatus),
     ],
+)
+
+BCSolarChargerLargeSolarCurrent = BBFrame(
+    output_id="live/solar_charger_ext",
+    fields=BCSolarChargerStandardFrame.fields
+    + [
+		#1 byte phase bits [0:3]: onyl valid when (status solar charger & 0x18 > 0)
+        #     0: Bulk
+        #     1: Absorption
+        #     2: Float
+        #     3: Care
+        BBValue("B", "solar_charger_phase", cnv.cnv_charger_phase),
+		#1 byte (09) MSB [23:16] solar max current per day (>= V418)
+		BBValue("B", "max_solar_current_day_up_A", lambda x: x * 0x10000 / 1000),
+		#1 byte (19) MSB [23:16] solar charge (>= V418)
+		BBValue("B", "solar_charge_day_up_Ah", lambda x: x * 0x10000 / 100),
+	],
 )
 
 BCBatteryComputer1Frame = BBFrame(
@@ -324,4 +399,30 @@ BCBoosterDataFrame = BBFrame(
         # TODO: unsigned
         BBValue("¾", "total_booster_charge_day_Ah", lambda x: x * (256 / 18000)),
     ],
+)
+
+BCBoosterDataFrameExtended = BBFrame(
+	output_id="live/booster",
+	fields=BCBoosterDataFrame.fields
+	+ [
+		#1 byte limit mode: 0x00: unknown, 0x01: off, 0x02: on
+		BBValue("B", "booster_limit"),
+		#1 byte phase bits [0:3]: only valid when (status booster & 0xc0 > 0)
+        #    0: Bulk
+        #    1: Absorption
+        #    2: Float
+        #    3: Care
+        BBValue("B", "booster_phase", cnv.cnv_charger_phase),
+	],
+)
+
+BCBoosterDataFrameExtendedBBX = BBFrame(
+	output_id="live/booster",
+	fields=BCBoosterDataFrameExtended.fields
+	+ [
+		#2 bytes value analog board voltage***
+		BBValue("H", "analog_board_voltage_V", cnv.cnv_mV_to_V),
+		#2 bytes value analog starter voltage***
+		BBValue("H", "analog_starter_voltage_V", cnv.cnv_mV_to_V),
+	],
 )

--- a/bluebattery/frametypes.py
+++ b/bluebattery/frametypes.py
@@ -396,6 +396,14 @@ BCIntradayLogEntryFrame = BBFrame(
     ],
 )
 
+BCIntradayLogEntryFrameExtended = BBFrame(
+    output_id="live/intraday_log",
+    fields= BCIntradayLogEntryFrame.fields
+    + [
+        BBValue("B", "log_type"),
+    ],
+)
+
 BCNoBoosterDataFrame = BBFrame(
     output_id="live/info",
     fields=[


### PR DESCRIPTION
- there are extended data formats to allow for larger solar currents > 65.5A.
- reports solar charger and booster charging phases.
- reports additionally analog measured board, starter battery voltages
